### PR TITLE
Test compilers on MacOs and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ on:
 env:
   # Modify these variables for upstream package versions - do NOT hardcode the version
   # anywhere else!
-  OPENFHE_VERSION: '1.2.0'
-  LIBCXXWRAP_JULIA_VERSION: '0.12.2'
-  FORCE_CXXWRAP_JL_VERSION: '0.15' # Use only briefly during transition (default: '')
+  OPENFHE_VERSION: '1.1.4'
+  LIBCXXWRAP_JULIA_VERSION: '0.13.0'
+  FORCE_CXXWRAP_JL_VERSION: '0.16' # Use only briefly during transition (default: '')
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.9'
-            compiler: gcc
-            gcc: 13
           - os: ubuntu-latest
             shell: bash
             julia_version: '1.10'
@@ -58,8 +56,6 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.10'
-            compiler: gcc
-            gcc: 13
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:
@@ -67,11 +63,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v2.22.0
         if: ${{ matrix.os == 'windows-latest' }}
-        env:
-          CC: gcc-${{ matrix.gcc }}
-          CXX: g++-${{ matrix.gcc }} 
         with:
           update: true
           install: git base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on:
 env:
   # Modify these variables for upstream package versions - do NOT hardcode the version
   # anywhere else!
-  OPENFHE_VERSION: '1.1.4'
+  OPENFHE_VERSION: '1.2.0'
   LIBCXXWRAP_JULIA_VERSION: '0.12.2'
   FORCE_CXXWRAP_JL_VERSION: '0.15' # Use only briefly during transition (default: '')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.9'
-            compiler: "GCC-13"
           - os: ubuntu-latest
             shell: bash
             julia_version: '1.10'
@@ -57,7 +56,6 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.10'
-            compiler: "GCC-13"
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:
@@ -70,6 +68,7 @@ jobs:
         with:
           update: true
           install: git base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake
+          compiler: "GCC-13"
       - name: Install OpenMP
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.9'
+            compiler: gcc
+            gcc: 13
           - os: ubuntu-latest
             shell: bash
             julia_version: '1.10'
@@ -56,6 +58,8 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.10'
+            compiler: gcc
+            gcc: 13
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:
@@ -65,10 +69,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.os == 'windows-latest' }}
+        env:
+          CC: gcc-${{ matrix.gcc }}
+          CXX: g++-${{ matrix.gcc }} 
         with:
           update: true
           install: git base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake
-          compiler: "GCC-13"
       - name: Install OpenMP
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
           path: openfhe-development/
           key: ${{ matrix.os }}-openfhe-v${{ env.OPENFHE_VERSION }}
       - name: Install OpenFHE
-        if: steps.cache-openfhe.outputs.cache-hit != 'true'
         run: |
           rm -rf openfhe-development
           mkdir -p openfhe-development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.9'
+            compiler: "GCC-13"
           - os: ubuntu-latest
             shell: bash
             julia_version: '1.10'
@@ -56,6 +57,7 @@ jobs:
           - os: windows-latest
             shell: 'msys2 {0}'
             julia_version: '1.10'
+            compiler: "GCC-13"
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: msys2/setup-msys2@v2.22.0
         if: ${{ matrix.os == 'windows-latest' }}
         with:
-          update: true
+          update: false
           install: git base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake
       - name: Install OpenMP
         if: ${{ matrix.os == 'macos-latest' }}
@@ -88,6 +88,7 @@ jobs:
           path: openfhe-development/
           key: ${{ matrix.os }}-openfhe-v${{ env.OPENFHE_VERSION }}
       - name: Install OpenFHE
+        if: steps.cache-openfhe.outputs.cache-hit != 'true'
         run: |
           rm -rf openfhe-development
           mkdir -p openfhe-development

--- a/src/openfhe_julia.cpp
+++ b/src/openfhe_julia.cpp
@@ -77,3 +77,4 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
   wrap_GenCryptoContext(mod);
   wrap_auxiliary(mod);
 }
+

--- a/src/openfhe_julia.cpp
+++ b/src/openfhe_julia.cpp
@@ -77,4 +77,3 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
   wrap_GenCryptoContext(mod);
   wrap_auxiliary(mod);
 }
-


### PR DESCRIPTION
#52 has an unexpected issue with compilation of openfhe-development v1.2.0 on MacOs and Windows, it seems to be a compiler issue. This PR is created only for test, whether older version of openfhe-development gets compilated with GCC v14.1 and Clang 15.0, in all successful PRs before was used older version of GCC v13.2. I want to know it the problem in new openfhe-development version or in new version of gcc