### PR TITLE
UndefVarError: `StdFill` not defined MacOS 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,12 @@ jobs:
         env:
           JULIA_BINDIR: ${{ steps.setup-julia.outputs.julia-bindir }}
       - name: Initialize basic Julia tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           cd test
           julia --color=yes init.jl $LIBOPENFHE_JULIA_PATH
       - name: Run basic Julia tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           julia --color=yes --project=test test/test.jl
         # The following env setting is required until

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,12 +148,10 @@ jobs:
         env:
           JULIA_BINDIR: ${{ steps.setup-julia.outputs.julia-bindir }}
       - name: Initialize basic Julia tests
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           cd test
           julia --color=yes init.jl $LIBOPENFHE_JULIA_PATH
       - name: Run basic Julia tests
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           julia --color=yes --project=test test/test.jl
         # The following env setting is required until

--- a/src/openfhe_julia.cpp
+++ b/src/openfhe_julia.cpp
@@ -29,7 +29,10 @@
 #include "openfhe_julia/cryptocontextfactory.h"
 #include "openfhe_julia/auxiliary.h"
 
-
+// Until https://github.com/JuliaInterop/CxxWrap.jl/issues/455 is not solved
+#ifdef __APPLE__
+    #undef JLCXX_HAS_RANGES
+#endif
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
   // Enums

--- a/src/openfhe_julia.cpp
+++ b/src/openfhe_julia.cpp
@@ -29,7 +29,7 @@
 #include "openfhe_julia/cryptocontextfactory.h"
 #include "openfhe_julia/auxiliary.h"
 
-// Until https://github.com/JuliaInterop/CxxWrap.jl/issues/455 is not solved
+// Required until https://github.com/JuliaInterop/CxxWrap.jl/issues/455 has been solved
 #ifdef __APPLE__
     #undef JLCXX_HAS_RANGES
 #endif

--- a/src/openfhe_julia.cpp
+++ b/src/openfhe_julia.cpp
@@ -30,6 +30,7 @@
 #include "openfhe_julia/auxiliary.h"
 
 
+
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
   // Enums
   wrap_PKESchemeFeature(mod);


### PR DESCRIPTION
I've encountered a compilation Error of OpenFHE.jl on MacOS: `UndefVarError: StdFill not defined`.

I have no Mac, so I cannot test this solution, but it has helped in this issue to solve similar problem: https://github.com/JuliaInterop/CxxWrap.jl/issues/455.

I would merge it, post a new release and update Yggdrasil.jl, so that all works properly

Full Error: https://github.com/hpsc-lab/SecureArithmetic.jl/actions/runs/12793306974/job/35665836464?pr=59 